### PR TITLE
Fix nomenclature of ARM architectures

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ Platforms and architectures currently supported:
 * MacOS X (x86-64), 10.7+
 * Linux (x86, x86-64, PPC, ARM)
 * FreeBSD (x86, x86-64, PPC, ARM)
-* iOS (ARM7, ARM7s, ARM64), 6.0+
-* Android (ARM6, ARM7, ARM8-AARCH64, x86, x86-64, MIPS, MIPS64)
-* Raspberry Pi (ARM6)
+* iOS (ARMv7, ARMv7s, ARMv8/AArch64), 6.0+
+* Android (ARMv6, ARMv7, ARMv8/AArch64, x86, x86-64, MIPS, MIPS64)
+* Raspberry Pi (ARMv6)
 * PNaCl
 
 


### PR DESCRIPTION
I noticed this small error in the README with the nomenclature of the ARM-related architectures listed for support: the v symbol is used to separate the architecture versions from the CPU versions themselves. For example, the ARM7TDMI supports __ARMv4__ code, not ARMv7 code; ARM9 CPUs tend to run ARMv5, ARM11 CPUs run ARMv6, and so on.